### PR TITLE
corrigindo bug que deixa o menu-mb maior que a pagina

### DIFF
--- a/assets/css/partials/header.css
+++ b/assets/css/partials/header.css
@@ -96,13 +96,13 @@
 
 @media screen and (max-width: 700px) {
     .logoNav img {
-        width: 70px;
+        width: 80px;
     }
     .hamburguer {
         display: block;
         position: absolute;
         top: 45px;
-        right: 65px;
+        right: 55px;
         z-index: 999;
     }
     .menu {
@@ -121,5 +121,11 @@
     .menu.active {
         right: -100%;
         display: none;
+    }
+}
+
+@media screen and (max-width: 380px) {
+    .menu {
+        height: 740px;
     }
 }


### PR DESCRIPTION
Corrigindo a altura do menu mobile, que quando abria, ficava maior que a página.